### PR TITLE
Fix for iOS 11 & Xcode 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 #Pods/
+.DS_Store

--- a/objc/04-DrawingIn3D/DrawingIn3D/MBEMetalView.m
+++ b/objc/04-DrawingIn3D/DrawingIn3D/MBEMetalView.m
@@ -125,7 +125,8 @@
                                                                                         width:drawableSize.width
                                                                                        height:drawableSize.height
                                                                                     mipmapped:NO];
-
+        desc.usage = MTLTextureUsageRenderTarget;
+        
         self.depthTexture = [self.metalLayer.device newTextureWithDescriptor:desc];
     }
 }

--- a/objc/05-Lighting/Lighting/MBEMetalView.m
+++ b/objc/05-Lighting/Lighting/MBEMetalView.m
@@ -125,7 +125,7 @@
                                                                                         width:drawableSize.width
                                                                                        height:drawableSize.height
                                                                                     mipmapped:NO];
-
+        desc.usage = MTLTextureUsageRenderTarget;
         self.depthTexture = [self.metalLayer.device newTextureWithDescriptor:desc];
     }
 }

--- a/objc/06-Texturing/Texturing/MBEMetalView.m
+++ b/objc/06-Texturing/Texturing/MBEMetalView.m
@@ -125,7 +125,7 @@
                                                                                         width:drawableSize.width
                                                                                        height:drawableSize.height
                                                                                     mipmapped:NO];
-
+        desc.usage = MTLTextureUsageRenderTarget;
         self.depthTexture = [self.metalLayer.device newTextureWithDescriptor:desc];
     }
 }

--- a/objc/07-Mipmapping/Mipmapping/MBERenderer.m
+++ b/objc/07-Mipmapping/Mipmapping/MBERenderer.m
@@ -138,6 +138,7 @@ static const vector_float3 Y = { 0, 1, 0 };
                                                                                             width:drawableSize.width
                                                                                            height:drawableSize.height
                                                                                         mipmapped:NO];
+    depthTexDesc.usage = MTLTextureUsageRenderTarget;
     self.depthTexture = [self.device newTextureWithDescriptor:depthTexDesc];
 }
 

--- a/objc/08-CubeMapping/CubeMapping/MBERenderer.m
+++ b/objc/08-CubeMapping/CubeMapping/MBERenderer.m
@@ -118,6 +118,7 @@
                                                                                             width:drawableSize.width
                                                                                            height:drawableSize.height
                                                                                         mipmapped:NO];
+    depthTexDesc.usage = MTLTextureUsageRenderTarget;
     self.depthTexture = [self.device newTextureWithDescriptor:depthTexDesc];
 }
 

--- a/objc/10-AlphaBlending/AlphaBlending/MBERenderer.m
+++ b/objc/10-AlphaBlending/AlphaBlending/MBERenderer.m
@@ -203,6 +203,7 @@ static const size_t MBETreeUniformOffset = MBEWaterUniformOffset + sizeof(Instan
                                                                                           width:drawableSize.width
                                                                                          height:drawableSize.height
                                                                                       mipmapped:NO];
+    descriptor.usage = MTLTextureUsageRenderTarget;
     self.depthTexture = [self.device newTextureWithDescriptor:descriptor];
     [self.depthTexture setLabel:@"Depth Texture"];
 }

--- a/objc/11-InstancedDrawing/InstancedDrawing/MBERenderer.m
+++ b/objc/11-InstancedDrawing/InstancedDrawing/MBERenderer.m
@@ -194,6 +194,7 @@ static inline float random_unit_float()
                                                                                           width:drawableSize.width
                                                                                          height:drawableSize.height
                                                                                       mipmapped:NO];
+    descriptor.usage = MTLTextureUsageRenderTarget;
     self.depthTexture = [self.device newTextureWithDescriptor:descriptor];
     [self.depthTexture setLabel:@"Depth Texture"];
 }

--- a/objc/12-TextRendering/TextRendering/MBERenderer.m
+++ b/objc/12-TextRendering/TextRendering/MBERenderer.m
@@ -174,6 +174,7 @@ static float MBEFontAtlasSize = 2048;
                                                                                           width:drawableSize.width
                                                                                          height:drawableSize.height
                                                                                       mipmapped:NO];
+    descriptor.usage = MTLTextureUsageRenderTarget;
     self.depthTexture = [self.device newTextureWithDescriptor:descriptor];
     [self.depthTexture setLabel:@"Depth Texture"];
 }

--- a/objc/14-ImageProcessing/ImageProcessing/MBEImageFilter.m
+++ b/objc/14-ImageProcessing/ImageProcessing/MBEImageFilter.m
@@ -47,6 +47,7 @@
                                                                                                      width:[inputTexture width]
                                                                                                     height:[inputTexture height]
                                                                                                  mipmapped:NO];
+        textureDescriptor.usage = MTLTextureUsageShaderWrite|MTLTextureUsageShaderRead;
         self.internalTexture = [self.context.device newTextureWithDescriptor:textureDescriptor];
     }
     


### PR DESCRIPTION
I've added the texture usages in the descriptors so that all the samples work as-is with Metal validation.

It's probably required for earlier versions of iOS but I tested on iOS 11 using Xcode 9 beta.
